### PR TITLE
MW-1471: Activate Prometheus metrics endpoint

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ repositories {
 
 dependencies {
     compile "org.springframework.boot:spring-boot-starter-actuator"
+    compile "io.micrometer:micrometer-registry-prometheus"
     compile "org.springframework.boot:spring-boot-starter-web"
     compile "org.springframework.boot:spring-boot-starter-data-jpa"
     compile "org.postgresql:postgresql:42.6.2"

--- a/src/main/java/org/openlmis/hapifhir/security/ResourceServerSecurityConfiguration.java
+++ b/src/main/java/org/openlmis/hapifhir/security/ResourceServerSecurityConfiguration.java
@@ -86,6 +86,7 @@ public class ResourceServerSecurityConfiguration implements ResourceServerConfig
         .authorizeRequests()
         .antMatchers(
             "/actuator/health",
+            "/actuator/prometheus",
             "/hapifhir",
             "/webjars/**",
             "/hapifhir/webjars/**",

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -36,7 +36,8 @@ spring.jpa.properties.hibernate.search.lucene_version=LUCENE_CURRENT
 
 management.endpoints.enabled-by-default=false
 management.endpoint.health.enabled=true
-management.endpoints.web.exposure.include=health
+management.endpoint.prometheus.enabled=true
+management.endpoints.web.exposure.include=health,prometheus
 
 spring.jpa.show-sql=false
 


### PR DESCRIPTION
Activates the Prometheus (Micrometer) actuator endpoint so JVM/HTTP metrics can be scraped by a Grafana Alloy agent (OpenLMIS Malawi monitoring). build.gradle adds micrometer-registry-prometheus (actuator starter already on master); application.properties enables+exposes the prometheus endpoint (management.endpoint.prometheus.enabled=true; master sets enabled-by-default=false); ResourceServerSecurityConfiguration permits /actuator/prometheus (like the existing /actuator/health). The FHIR servlet is mapped to /hapifhir/*, so /actuator/* is served by Spring's DispatcherServlet with no path conflict. Only reachable on the internal network in the Malawi deployment. Verified: builds, boots, GET /actuator/prometheus returns 200 (109 series). Companion hotfix branch rel-2.0.4-hotfix.1 carries the same activation on the deployed 2.0.4 line.